### PR TITLE
Feature: As a user, I want to be able to reset the selected business feature and service filters by selecting the `reset filter` button without a page reload (#Hair-128) 

### DIFF
--- a/client/src/UIElements/Card.tsx
+++ b/client/src/UIElements/Card.tsx
@@ -1,7 +1,6 @@
 import './Card.css'
-
 export const Card = props => {
-  console.log('in card, props', props)
+  // console.log('in card, props', props)
   return (
     <div className={`card ${props.className}`} style={props.style}>
       {props.children}

--- a/client/src/components/FilterServicesAndFeatures/FilterServicesAndFeatures.tsx
+++ b/client/src/components/FilterServicesAndFeatures/FilterServicesAndFeatures.tsx
@@ -84,6 +84,7 @@ export const FilterServicesAndFeatures = (props: Props) => {
     props.setFilteredResults(() => {
       return [...props.list]
     })
+  }
 
   //* Monitor changes to the filtered Features and Services arrays. If there are changes send the data to the `BusinessList` Parent component
   useEffect(() => {

--- a/client/src/components/FilterServicesAndFeatures/FilterServicesAndFeatures.tsx
+++ b/client/src/components/FilterServicesAndFeatures/FilterServicesAndFeatures.tsx
@@ -1,26 +1,36 @@
-// React Components
+//* React Components
 import { useState, useEffect } from 'react'
 
-// Custom Imports
+//* Custom Imports
 import { LoadSpinner } from '../LoadSpinner/LoadSpinner'
 
-// Custom Styles
+//* Custom Styles
 import './FilterServicesAndFeatures.css'
 
-// Types
+//* Types
 interface Props {
   loading: boolean
+  list: any
   onFeatChange: any
   onServiceChange: any
   servicesArr: any
   featuresArr: any
-  handleResetFilter: any
+  setFeaturesArr: any
+  setServicesArr: any
+  filteredResults: any
+  setFilteredResults: any
   handleFilteredResults: any
+}
+
+interface ObjectCheckboxes {
+  [key: string]: any
 }
 
 export const FilterServicesAndFeatures = (props: Props) => {
   const [isLoading, setIsLoading] = useState(true)
 
+  //* Initialize State Objects for Form Checkboxes
+  const [isChecked, setIsChecked]: any = useState(false)
   //* Initialize Arrays for Selected Business Features and Services
   const [filteredFeats, setFilteredFeats]: any = useState([])
   const [filteredServices, setFilteredServices]: any = useState([])
@@ -29,6 +39,7 @@ export const FilterServicesAndFeatures = (props: Props) => {
   const onFeatChange: React.ChangeEventHandler<HTMLInputElement> = event => {
     const { name, checked, id } = event.target
     // console.log('id', id, 'checked', checked)
+    setIsChecked(!isChecked)
     // setFilteredFeats({ ...filteredFeats, [`${name} (${id})`]: checked })
     setFilteredFeats({ ...filteredFeats, [`${id}`]: checked })
   }
@@ -37,10 +48,42 @@ export const FilterServicesAndFeatures = (props: Props) => {
   const onServiceChange: React.ChangeEventHandler<HTMLInputElement> = event => {
     const { name, checked, id } = event.target
     // console.log('id', id, 'checked', checked)
+    setIsChecked(!isChecked)
     // setFilteredServices({ ...filteredServices, [`${name} (${id})`]: checked })
     setFilteredServices({ ...filteredServices, [`${id}`]: checked })
   }
   // console.log('filteredServices onChange', filteredServices)
+  const handleResetFilter = (): any => {
+    //* Create an object of checkboxes
+    let objectCheckboxes = document.getElementsByClassName('Filters-FormCheckInput')
+
+    setIsChecked(!isChecked)
+
+    if (!objectCheckboxes) return
+
+    if (objectCheckboxes.length > 0) {
+      //* Loop through the object of checkboxes
+      Object.values(objectCheckboxes).forEach(checkbox => {
+        //* Set Checkboxes to false
+        let a = checkbox as HTMLInputElement
+        a.checked = false
+      })
+    }
+
+    //* Reset `filteredFeats` state object to the initial state of an empty array though later set inside an object.
+    setFilteredFeats(filteredFeats => {
+      return (filteredFeats = [])
+    })
+
+    //* Reset `filteredServices` state object to the initial state an empty array though later set inside an object.
+    setFilteredServices(filteredServices => {
+      return (filteredServices = [])
+    })
+
+    //* Reset `filteredResults` state object to the initial state, Business List filtered by City.
+    props.setFilteredResults(() => {
+      return [...props.list]
+    })
 
   //* Monitor changes to the filtered Features and Services arrays. If there are changes send the data to the `BusinessList` Parent component
   useEffect(() => {
@@ -48,11 +91,14 @@ export const FilterServicesAndFeatures = (props: Props) => {
       props.onFeatChange(filteredFeats)
       // console.log('filteredFeats useEffect changes', filteredFeats)
     }
+    props.onFeatChange(filteredFeats)
     if (props.onServiceChange) {
       props.onServiceChange(filteredServices)
       // console.log('filteredServices useEffect changes', filteredServices)
     }
+    props.onServiceChange(filteredServices)
   }, [filteredFeats, filteredServices])
+
   return (
     <>
       {!props.loading ? (
@@ -63,7 +109,16 @@ export const FilterServicesAndFeatures = (props: Props) => {
           <div className='Filters-FormGroup'>
             {props.featuresArr?.map((feature, id, index) => (
               <div className='Filters-FormCheck' key={`${feature}_` + index}>
-                <input className='Filters-FormCheckInput' type='checkbox' name={`feature-${feature[0]}`} id={feature[1]} defaultChecked={feature[2].isChecked} value={id} onChange={onFeatChange} />
+                <input
+                  className='Filters-FormCheckInput'
+                  type='checkbox'
+                  name={`feature-${feature[0]}`}
+                  value={id}
+                  id={feature[1]}
+                  // defaultChecked={feature[2].isChecked}
+                  checked={isChecked[index]}
+                  onChange={onFeatChange}
+                />
                 <label className='Filters-FormCheckLabel' htmlFor={feature[1]}>
                   {feature[0]}
                 </label>
@@ -76,7 +131,16 @@ export const FilterServicesAndFeatures = (props: Props) => {
           <div className='Filters-FormGroup'>
             {props.servicesArr?.map((service, id, index) => (
               <div className='Filters-FormCheck' key={`${service}_` + index}>
-                <input className='Filters-FormCheckInput' type='checkbox' name={`service-${service[0]}`} id={service[1]} defaultChecked={service[2].isChecked} value={id} onChange={onServiceChange} />
+                <input
+                  className='Filters-FormCheckInput'
+                  type='checkbox'
+                  name={`service-${service[0]}`}
+                  value={id}
+                  id={service[1]}
+                  // defaultChecked={service[2].isChecked}
+                  checked={isChecked[index]}
+                  onChange={onServiceChange}
+                />
                 <label className='Filters-FormCheckLabel' htmlFor={service[1]}>
                   {service[0]}
                 </label>
@@ -86,7 +150,7 @@ export const FilterServicesAndFeatures = (props: Props) => {
           <button className='Filters-Button' onClick={props.handleFilteredResults}>
             filter results
           </button>
-          <button className='Reset-Button' onClick={props.handleResetFilter}>
+          <button className='Reset-Button' onClick={handleResetFilter}>
             reset filters
           </button>
         </section>

--- a/client/src/components/LoadSpinner/LoadSpinner.css
+++ b/client/src/components/LoadSpinner/LoadSpinner.css
@@ -26,7 +26,7 @@
   top: 48px;
   position: absolute;
   animation: ldio-cs9r5gg8z0w linear 1s infinite;
-  background: #456caa;
+  background: #f32dc8;
   margin-top: 10rem;
   width: 12px;
   height: 24px;
@@ -36,60 +36,60 @@
 .ldio-cs9r5gg8z0w div:nth-child(1) {
   transform: rotate(0deg);
   animation-delay: -0.9166666666666666s;
-  background: #456caa;
+  background: #f32dc8;
 }
 .ldio-cs9r5gg8z0w div:nth-child(2) {
   transform: rotate(30deg);
   animation-delay: -0.8333333333333334s;
-  background: #456caa;
+  background: #f32dc8;
 }
 .ldio-cs9r5gg8z0w div:nth-child(3) {
   transform: rotate(60deg);
   animation-delay: -0.75s;
-  background: #456caa;
+  background: #f32dc8;
 }
 .ldio-cs9r5gg8z0w div:nth-child(4) {
   transform: rotate(90deg);
   animation-delay: -0.6666666666666666s;
-  background: #456caa;
+  background: #f32dc8;
 }
 .ldio-cs9r5gg8z0w div:nth-child(5) {
   transform: rotate(120deg);
   animation-delay: -0.5833333333333334s;
-  background: #456caa;
+  background: #f32dc8;
 }
 .ldio-cs9r5gg8z0w div:nth-child(6) {
   transform: rotate(150deg);
   animation-delay: -0.5s;
-  background: #456caa;
+  background: #f32dc8;
 }
 .ldio-cs9r5gg8z0w div:nth-child(7) {
   transform: rotate(180deg);
   animation-delay: -0.4166666666666667s;
-  background: #456caa;
+  background: #f32dc8;
 }
 .ldio-cs9r5gg8z0w div:nth-child(8) {
   transform: rotate(210deg);
   animation-delay: -0.3333333333333333s;
-  background: #456caa;
+  background: #f32dc8;
 }
 .ldio-cs9r5gg8z0w div:nth-child(9) {
   transform: rotate(240deg);
   animation-delay: -0.25s;
-  background: #456caa;
+  background: #f32dc8;
 }
 .ldio-cs9r5gg8z0w div:nth-child(10) {
   transform: rotate(270deg);
   animation-delay: -0.16666666666666666s;
-  background: #456caa;
+  background: #f32dc8;
 }
 .ldio-cs9r5gg8z0w div:nth-child(11) {
   transform: rotate(300deg);
   animation-delay: -0.08333333333333333s;
-  background: #456caa;
+  background: #f32dc8;
 }
 .ldio-cs9r5gg8z0w div:nth-child(12) {
   transform: rotate(330deg);
   animation-delay: 0s;
-  background: #456caa;
+  background: #f32dc8;
 }

--- a/client/src/pages/BusinessList/BusinessList.tsx
+++ b/client/src/pages/BusinessList/BusinessList.tsx
@@ -220,12 +220,6 @@ export const BusinessList = () => {
     })
   }, [list, city])
 
-  const handleResetFilter = (): any => {
-    // TODO: [ ] => FIXME: Reset checkboxes to false
-    //? TODO: [ ] => Explore connecting to child component to allow for checkbox resetting to opposite of checked
-    window.location.reload()
-  }
-
   if (loading) {
     return (
       <div
@@ -272,7 +266,6 @@ export const BusinessList = () => {
                 onFeatChange={onFeatChange}
                 onServiceChange={onServiceChange}
                 loading={loading}
-                handleResetFilter={handleResetFilter}
                 handleFilteredResults={handleFilteredResults}
               />
             </div>

--- a/client/src/pages/BusinessList/BusinessList.tsx
+++ b/client/src/pages/BusinessList/BusinessList.tsx
@@ -261,11 +261,16 @@ export const BusinessList = () => {
           <div className='BusinessList-Container'>
             <div className='BusinessList-Filters'>
               <FilterServicesAndFeatures
+                loading={loading}
+                list={list}
+                filteredResults={filteredResults}
+                setFilteredResults={setFilteredResults}
                 featuresArr={featuresArr}
+                setFeaturesArr={setFeaturesArr}
                 servicesArr={servicesArr}
+                setServicesArr={setServicesArr}
                 onFeatChange={onFeatChange}
                 onServiceChange={onServiceChange}
-                loading={loading}
                 handleFilteredResults={handleFilteredResults}
               />
             </div>

--- a/client/src/pages/BusinessList/BusinessList.tsx
+++ b/client/src/pages/BusinessList/BusinessList.tsx
@@ -1,17 +1,17 @@
-// React Components
+//* React Components
 import { useState, useEffect } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
 
-// Custom Imports
+//* Custom Imports
 import { Card } from '../../UIElements/Card'
 import { CardDetails } from '../../components/CardDetails/CardDetails'
 import { FilterServicesAndFeatures } from '../../components/FilterServicesAndFeatures/FilterServicesAndFeatures'
 import { LoadSpinner } from '../../components/LoadSpinner/LoadSpinner'
 
-// Custom Styles
+//* Custom Styles
 import './BusinessList.css'
 
-// Types
+//* Types
 interface RouteParams {
   city: string
 }
@@ -59,7 +59,7 @@ export const BusinessList = () => {
   const [featuresArr, setFeaturesArr]: any = useState([])
   const [servicesArr, setServicesArr]: any = useState([])
 
-  // //* Initialize state objects for form checkboxes
+  //* Initialize state objects for form checkboxes
   // // TODO: [ ] => Connect with `handleResetFilter` to reset checkboxes to false
   // const [isChecked, setIsChecked]: any = useState(false)
   // const [isFeatsChecked, setIsFeatsChecked]: any = useState([])
@@ -272,7 +272,6 @@ export const BusinessList = () => {
                 onFeatChange={onFeatChange}
                 onServiceChange={onServiceChange}
                 loading={loading}
-                // isChecked={isChecked}
                 handleResetFilter={handleResetFilter}
                 handleFilteredResults={handleFilteredResults}
               />

--- a/client/src/pages/BusinessList/BusinessList.tsx
+++ b/client/src/pages/BusinessList/BusinessList.tsx
@@ -155,10 +155,12 @@ export const BusinessList = () => {
   const handleFilteredResults = (): [] => {
     let tempFilteredResults: any[] = []
     let tempSelectedFeatsServices: any[] = []
+
     //* Push user selected Features to a single temp array, if the filtered array/object is not empty
-    if (Object.keys(filteredFeats).length > 0) {
+    let deepCopyFilterFeats = JSON.parse(JSON.stringify(filteredFeats))
+    if (Object.keys(deepCopyFilterFeats).length > 0) {
       //* Filter out elements that are only true and push those true objects to tempSelectedFeatsServices
-      Object.entries(filteredFeats).filter(featureElement => {
+      Object.entries(deepCopyFilterFeats).filter(featureElement => {
         if (featureElement[1] === true) {
           tempSelectedFeatsServices.push(featureElement)
           return true
@@ -166,9 +168,10 @@ export const BusinessList = () => {
       })
     }
     //* Push user selected Services to a single temp array, if the filtered array/object is not empty
-    if (Object.keys(filteredServices).length > 0) {
+    let deepCopyFilterServices = JSON.parse(JSON.stringify(filteredServices))
+    if (Object.keys(deepCopyFilterServices).length > 0) {
       //* Filter out elements that are only true and push those true objects to tempSelectedFeatsServices
-      Object.entries(filteredServices).filter(featureElement => {
+      Object.entries(deepCopyFilterServices).filter(featureElement => {
         if (featureElement[1] === true) {
           tempSelectedFeatsServices.push(featureElement)
           return true


### PR DESCRIPTION
## Description
This Pull Request (PR) adds a new feature to the `<BusinessList/>` page allowing users to be able to reset selected business feature and service filters by selecting the `reset filter` button without a page reload.

## Acceptance Criteria

- [ ] `onClick` the `reset filter` button resets any selected business feature and service checkbox to a `false` state without reloading the page.
- [ ] `onClick` the `reset filter` button removes any business feature and service filter on the list of businesses and returns the full, original list companies without reloading the page.

## Related Issue/Ticket
Closes #128

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|   ✅   | :bug: Bug fix(es)              |
| ✅    | :sparkles: New feature     |
| ✅    | :hammer: Refactoring       |
|     | :100: Add tests            |
|   | :link: Update dependencies |
|     | :scroll: Docs              |

## UI Updates

<details>
<summary>Business List Page UI Updates</summary>

- ## Reset Selected Business Features and Services

|   Previous UI  | PR Update                       |
| --- | -------------------------- |
| ![resetFilterButtonFeature](https://user-images.githubusercontent.com/32943879/177055351-90e43de8-b8e7-4752-baa6-6ccc91ffd638.gif) | ![resetFilterButtonFeature](https://user-images.githubusercontent.com/32943879/177055351-90e43de8-b8e7-4752-baa6-6ccc91ffd638.gif)

![resetFilterButtonFeature](https://user-images.githubusercontent.com/32943879/177055351-90e43de8-b8e7-4752-baa6-6ccc91ffd638.gif)
</details>